### PR TITLE
Fixed a null runtime error in HexBlock.java

### DIFF
--- a/src/javacamod/world/blocks/decoration/HexBlock.java
+++ b/src/javacamod/world/blocks/decoration/HexBlock.java
@@ -130,7 +130,12 @@ public class HexBlock extends Block{
                 @Override
                 public void configured(Unit player, Object value){
                     super.configured(player, value);
- 
+
+			// Ensures that headless is not null. If it is, then return out of the function. This
+			// prevents a runtime error. 
+			if (headless == null) {
+				return;
+			}
                         if(!headless){
                             renderer.minimap.update(tile);
                         }


### PR DESCRIPTION
A runtime null error would crash the mod. In order to (hopefully) fix this, I've added a check to ensure that headless is not null, and if it is, then it will return out of the function to ensure that the boolean check does not occur.